### PR TITLE
feat: validate collections now also checks if each project slug exists

### DIFF
--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -4,6 +4,7 @@ import { readCollectionFile, readProjectFile } from "../index.js";
 import { FileFormat } from "../types/files.js";
 import { UserError } from "../utils/error.js";
 import { assertNever } from "../utils/common.js";
+import { getProjectPath } from "../utils/format.js";
 
 export type ValidateArgs = {
   dir: string;
@@ -39,7 +40,13 @@ export async function validateCollections(args: ValidateArgs) {
   const { fileFormat, files } = await getFiles(args);
   console.log(`Validating collections in ${args.dir}`);
   for (const file of files) {
-    await readCollectionFile(file, { format: fileFormat });
+    // Check each file conforms to `Collection` schema
+    const collection = await readCollectionFile(file, { format: fileFormat });
+    // Make sure that all projects in the collection exist
+    for (const projectSlug of [...collection.projects]) {
+      const projectFile = getProjectPath(projectSlug);
+      await readProjectFile(projectFile, { format: fileFormat });
+    }
   }
   console.log(`Success! Validated ${files.length} files`);
 }
@@ -52,6 +59,7 @@ export async function validateProjects(args: ValidateArgs) {
   const { fileFormat, files } = await getFiles(args);
   console.log(`Validating projects in ${args.dir}`);
   for (const file of files) {
+    // Check each file conforms to `Project` schema
     await readProjectFile(file, { format: fileFormat });
   }
   console.log(`Success! Validated ${files.length} files`);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,53 @@
+import path from "path";
+
+const DEFAULT_BASE_DIRECTORY = "./data/";
+const DEFAULT_PROJECT_DIRECTORY = "./projects/";
+const DEFAULT_COLLECTION_DIRECTORY = "./collections/";
+const DEFAULT_EXTENSION = ".yaml";
+
+type PathOptions = {
+  baseDir?: string;
+  projectDir?: string;
+  collectionDir?: string;
+  extension?: string;
+};
+
+const getPathOptions = (opts?: PathOptions): Required<PathOptions> => ({
+  baseDir: opts?.baseDir ?? DEFAULT_BASE_DIRECTORY,
+  projectDir: opts?.projectDir ?? DEFAULT_PROJECT_DIRECTORY,
+  collectionDir: opts?.collectionDir ?? DEFAULT_COLLECTION_DIRECTORY,
+  extension: opts?.extension ?? DEFAULT_EXTENSION,
+});
+
+/**
+ * Given a collection slug, return the relative path to the collection file
+ * @param slug
+ * @returns
+ */
+function getCollectionPath(slug: string, opts?: PathOptions) {
+  const { baseDir, collectionDir, extension } = getPathOptions(opts);
+  const dir = path.join(baseDir, collectionDir);
+  return path.format({
+    root: dir,
+    name: slug,
+    ext: extension,
+  });
+}
+
+/**
+ * Given a project slug, return the relative path to the project file
+ * @param slug
+ * @returns
+ */
+function getProjectPath(slug: string, opts?: PathOptions) {
+  const { baseDir, projectDir, extension } = getPathOptions(opts);
+  const firstChar = `./${slug.charAt(0)}/`;
+  const dir = path.join(baseDir, projectDir, firstChar);
+  return path.format({
+    root: dir,
+    name: slug,
+    ext: extension,
+  });
+}
+
+export { getCollectionPath, getProjectPath };


### PR DESCRIPTION
* Add generic path formatting tools to get the path to a project or collection file
* Update collection validation logic to also enumerate through projects and make sure those files exist